### PR TITLE
fixing the H1 in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <header><h1>Money Conversor</h1></header>
+    <header><h1>Money Converter</h1></header>
     <section>
         <div class="container">
             <form>


### PR DESCRIPTION
Just modifying the H1 of 'money conversor' to 'money converter'. Just a typo.